### PR TITLE
libgralloc/libhwcomposer: Reduce calls to property_get() to improve performance.

### DIFF
--- a/msm8226/libgralloc/alloc_controller.cpp
+++ b/msm8226/libgralloc/alloc_controller.cpp
@@ -135,14 +135,6 @@ void AdrenoMemInfo::getAlignedWidthAndHeight(int width, int height, int format,
     if (format <= HAL_PIXEL_FORMAT_BGRA_8888) {
         aligned_w = ALIGN(width, 32);
         aligned_h = ALIGN(height, 32);
-        // Don't add any additional padding if debug.gralloc.map_fb_memory
-        // is enabled
-        char property[PROPERTY_VALUE_MAX];
-        if((property_get("debug.gralloc.map_fb_memory", property, NULL) > 0) &&
-           (!strncmp(property, "1", PROPERTY_VALUE_MAX ) ||
-           (!strncasecmp(property,"true", PROPERTY_VALUE_MAX )))) {
-              return;
-        }
 
         int bpp = 4;
         switch(format)

--- a/msm8226/libhwcomposer/hwc_mdpcomp.cpp
+++ b/msm8226/libhwcomposer/hwc_mdpcomp.cpp
@@ -1623,15 +1623,6 @@ int MDPComp::prepare(hwc_context_t *ctx, hwc_display_contents_1_t* list) {
     }
 
     const int numLayers = ctx->listStats[mDpy].numAppLayers;
-
-    if(property_get("debug.hwc.simulate", property, NULL) > 0) {
-        int currentFlags = atoi(property);
-        if(currentFlags != sSimulationFlags) {
-            sSimulationFlags = currentFlags;
-            ALOGE("%s: Simulation Flag read: 0x%x (%d)", __FUNCTION__,
-                    sSimulationFlags, sSimulationFlags);
-        }
-    }
     // reset PTOR
     if(!mDpy)
         memset(&(ctx->mPtorInfo), 0, sizeof(ctx->mPtorInfo));

--- a/msm8226/libhwcomposer/hwc_utils.cpp
+++ b/msm8226/libhwcomposer/hwc_utils.cpp
@@ -885,19 +885,6 @@ void setListStats(hwc_context_t *ctx,
             ctx->listStats[dpy].extOnlyLayerIndex = (int)i;
         }
     }
-    if(ctx->listStats[dpy].yuvCount > 0) {
-        if (property_get("hw.cabl.yuv", property, NULL) > 0) {
-            if (atoi(property) != 1) {
-                property_set("hw.cabl.yuv", "1");
-            }
-        }
-    } else {
-        if (property_get("hw.cabl.yuv", property, NULL) > 0) {
-            if (atoi(property) != 0) {
-                property_set("hw.cabl.yuv", "0");
-            }
-        }
-    }
 
     //The marking of video begin/end is useful on some targets where we need
     //to have a padding round to be able to shift pipes across mixers.


### PR DESCRIPTION
There are hooks in the property service to ensure that getting properties from Android libraries work under a libhybris system.
Adding support for the PROP_MSG_GETPROP seems to have caused a performance regression (reduction of ~10 fps) (https://github.com/AsteroidOS/android_system_core/commit/e2781ab79687d040d9301e0c5b8c3822e2da6fa3).
It isn't probably the actual cause though, since getAlignedWidthAndHeight() is the function that caused the performance regression. And a function that requests the width and height shouldn't be called for every frame.